### PR TITLE
Add timeout

### DIFF
--- a/YukariWhisper/recognizer.py
+++ b/YukariWhisper/recognizer.py
@@ -46,6 +46,7 @@ class myrecognizer:
         self.recognizers.phrase_threshold  = self.ini_file.phrase_threshold
         self.recognizers.non_speaking_duration  = self.ini_file.non_speaking_duration
         self.recognizers.energy_threshold_Low  = self.ini_file.energy_threshold_Low
+        self.recognizers.recognition_timeout = self.ini_file.recognition_timeout
 
         # websocket通信の設定
         self.wsocket = wsocket.wsocket('ws://localhost:', self.ini_file.local_port, self.ini_file.yukari_connect_neo)
@@ -116,6 +117,9 @@ class myrecognizer:
                     if self.vad.is_speech(speech_array):
                         #whisperで認識
                         segments = self.model_wrapper.transcribe(speech_array)
+                        # If the time takes longer than the specified seconds, discard the result. Determine before executing the loop.
+                        if round((time.time()-start_t), 1) >= self.recognizers.recognition_timeout:
+                            continue
                         for segment in segments:
                             # uniocode Normalization
                             normalized_text = unicodedata.normalize('NFC', segment.text)

--- a/YukariWhisper/recognizer.py
+++ b/YukariWhisper/recognizer.py
@@ -117,14 +117,14 @@ class myrecognizer:
                     if self.vad.is_speech(speech_array):
                         #whisperで認識
                         segments = self.model_wrapper.transcribe(speech_array)
-                        # If the time takes longer than the specified seconds, discard the result. Determine before executing the loop.
-                        if round((time.time()-start_t), 1) >= self.recognizers.recognition_timeout:
-                            continue
                         for segment in segments:
                             # uniocode Normalization
                             normalized_text = unicodedata.normalize('NFC', segment.text)
                             if self.check_ng_words(normalized_text):
-                               continue
+                                continue
+                            # If the time takes longer than the specified seconds, discard the result. Check the time after NG words.
+                            if round((time.time()-start_t), 1) >= self.recognizers.recognition_timeout:
+                                continue
                             if self.ini_file.debug_out_text:
                                 print(f"whisper[{(time.time()-start_t):.4f}]({len(segment.text)})" + normalized_text)
 

--- a/YukariWhisper/recognizer.py
+++ b/YukariWhisper/recognizer.py
@@ -120,7 +120,7 @@ class myrecognizer:
                         for segment in segments:
                             # 時間が指定秒以上かかる場合は結果を破棄して次の音声認識結果に移行する
                             if round((time.time()-start_t), 1) >= self.recognizers.recognition_timeout:
-                                print("Recognition was timeout.")
+                                print("音声認識がタイムアウトしました。")
                                 continue
                             # uniocode Normalization
                             normalized_text = unicodedata.normalize('NFC', segment.text)

--- a/YukariWhisper/recognizer.py
+++ b/YukariWhisper/recognizer.py
@@ -118,12 +118,13 @@ class myrecognizer:
                         #whisperで認識
                         segments = self.model_wrapper.transcribe(speech_array)
                         for segment in segments:
+                            # 時間が指定秒以上かかる場合は結果を破棄して次の音声認識結果に移行する
+                            if round((time.time()-start_t), 1) >= self.recognizers.recognition_timeout:
+                                print("Recognition was timeout.")
+                                continue
                             # uniocode Normalization
                             normalized_text = unicodedata.normalize('NFC', segment.text)
                             if self.check_ng_words(normalized_text):
-                                continue
-                            # If the time takes longer than the specified seconds, discard the result. Check the time after NG words.
-                            if round((time.time()-start_t), 1) >= self.recognizers.recognition_timeout:
                                 continue
                             if self.ini_file.debug_out_text:
                                 print(f"whisper[{(time.time()-start_t):.4f}]({len(segment.text)})" + normalized_text)

--- a/YukariWhisper/settings.py
+++ b/YukariWhisper/settings.py
@@ -20,6 +20,7 @@ class inifile_settings:
     pause_threshold = 0.8
     energy_threshold = 300
     energy_threshold_Low = 100
+    recognition_timeout = 5.0
     dynamic_energy_threshold = True
     dynamic_energy_adjustment_damping = 0.15
     dynamic_energy_ratio = 1.5
@@ -102,6 +103,7 @@ class inifile_settings:
         self.non_speaking_duration = ini_recognizer.getfloat('non_speaking_duration')
         self.vad_threshold = ini_recognizer.getfloat('vad_threshold')
         self.energy_threshold_Low = ini_recognizer.getfloat('energy_threshold_Low')
+        self.recognition_timeout = ini_recognizer.getfloat('recognition_timeout')
 
     #NGWORDSセクションの解析
     def parse_ngwords(self, chr_code):

--- a/YukariWhisper/settings.py
+++ b/YukariWhisper/settings.py
@@ -20,7 +20,7 @@ class inifile_settings:
     pause_threshold = 0.8
     energy_threshold = 300
     energy_threshold_Low = 100
-    recognition_timeout = 5.0
+    recognition_timeout = 10.0
     dynamic_energy_threshold = True
     dynamic_energy_adjustment_damping = 0.15
     dynamic_energy_ratio = 1.5

--- a/yukariwhisper.ini
+++ b/yukariwhisper.ini
@@ -84,6 +84,10 @@ energy_threshold_Low = 10.0
 ;音のエネルギーレベルの最低値を設定します。このしきい値以下には落ちないようにします。
 ;休息などで離席すると動的エネルギーしきい値が0にまで落ち込んで、PCのファンノイズなどを取り込んでしまう問題の暫定回避策です。
 
+recognition_timeout = 5.0
+;If speech recognition takes longer than the specified time, the result will be discarded and the next speech recognition result will be output.
+;Since abnormal speech recognition results generally take an abnormally long time to recognize, this feature was installed by UnknownRaven809R as a temporary workaround.
+
 [NGWORDS]
 ng_words_filename = ngwords.txt
 ;発話させない文字列のリストが入ったテキストファイル名を指定します。

--- a/yukariwhisper.ini
+++ b/yukariwhisper.ini
@@ -84,9 +84,9 @@ energy_threshold_Low = 10.0
 ;音のエネルギーレベルの最低値を設定します。このしきい値以下には落ちないようにします。
 ;休息などで離席すると動的エネルギーしきい値が0にまで落ち込んで、PCのファンノイズなどを取り込んでしまう問題の暫定回避策です。
 
-recognition_timeout = 5.0
-;If speech recognition takes longer than the specified time, the result will be discarded and the next speech recognition result will be output.
-;Since abnormal speech recognition results generally take an abnormally long time to recognize, this feature was installed by UnknownRaven809R as a temporary workaround.
+recognition_timeout = 10.0
+;ここで指定した時間以上に音声認識に時間がかかる場合は結果を破棄して、次の音声認識を処理します。デフォルトは10.0秒で、ユーザの環境に応じて変更できます。
+;ノイズを音声として認識していまい、それによって時間がかかる問題を回避するための暫定処置として追加しました。
 
 [NGWORDS]
 ng_words_filename = ngwords.txt


### PR DESCRIPTION
Allow recognition to time out after the configured user time.

The purpose of this pull request:
It has been found that when abnormal speech recognition results are output, it is common for the recognition to take an abnormally long time. In that case, it takes more than 5.0 seconds across the board.
Therefore, the default is 5.0 seconds or more, and speech recognition that exceeds this time will be discarded as a timeout. At the same time, it allows the user to change the timeout time arbitrarily.

Implementation details:
yukariwhisper.ini: Create new parameter "recognition_timeout = 5.0".
settings.py: settings.py: Create new parameter "recognition_timeout = 5.0" in class "inifile_settings" and new perser "self.recognition_timeout = ini_recognizer.getfloat('recognition_timeout')" in def "parse_recognizer(self)"
recognizer.py: Create parameter setting "self.recognizers.recognition_timeout = self.ini_file.recognition_timeout" in "__init__". And insert a conditional statement to determine whether the specified time has been exceeded after "segments = self.model_wrapper.transcribe(speech_array)". This uses "(time.time()-start_t)". Currently, I am using round() to format it to the first decimal place and refer to it.

I have implemented all of these myself and have confirmed that they work.